### PR TITLE
use cyclonedx lib to generate dummy pom

### DIFF
--- a/cvereporter/report.py
+++ b/cvereporter/report.py
@@ -1,0 +1,50 @@
+from cyclonedx.exception import MissingOptionalDependencyException
+from cyclonedx.factory.license import LicenseFactory
+from cyclonedx.model import OrganizationalEntity, XsUri
+from cyclonedx.model.bom import Bom
+from cyclonedx.model.component import Component, ComponentType
+from cyclonedx.model.impact_analysis import ImpactAnalysisAffectedStatus
+from cyclonedx.model.vulnerability import Vulnerability, VulnerabilitySource,VulnerabilityScoreSource, VulnerabilityRating, VulnerabilitySeverity, BomTarget, BomTargetVersionRange
+from cyclonedx.output import make_outputter, LATEST_SUPPORTED_SCHEMA_VERSION
+from cyclonedx.output.json import JsonV1Dot4
+from cyclonedx.schema import SchemaVersion, OutputFormat
+from cyclonedx.validation.json import JsonStrictValidator
+from cyclonedx.validation import make_schemabased_validator
+from datetime import datetime
+
+# based on sample code from https://cyclonedx-python-library.readthedocs.io/en/latest/examples.html
+lc_factory = LicenseFactory()
+bom = Bom()
+bom.metadata.component = root_component = Component(
+    name='Eclipse Temurin',
+    type=ComponentType.APPLICATION,
+    licenses=[lc_factory.make_from_string('GPL v2')],
+    bom_ref='temurin-vdr',
+)
+
+
+vuln1 = Vulnerability(
+    id="CVE-2-23-25193",
+    source=VulnerabilitySource(name="NVD", url="https://nvd.nist.gov/vuln/detail/CVE-2023-25193"),
+    published=datetime.strptime("2023-02-04T20:15:08.027", "%Y-%m-%dT%H:%M:%S.%f"),
+    updated=datetime.strptime("2023-07-25T15:15:13.163", "%Y-%m-%dT%H:%M:%S.%f"),
+    description="hb-ot-layout-gsubgpos.hh in HarfBuzz through 6.0.0 allows attackers to trigger O(n^2) growth via consecutive marks during the process of looking back for base glyphs when attaching marks.",
+    recommendation="Upgrade to the latest version of Eclipse Temurin."
+)
+
+rating1 = VulnerabilityRating(
+    source=VulnerabilitySource(url= "https://openjdk.org/groups/vulnerability/advisories", name="OJVG"),
+    score=3.7,
+    severity=VulnerabilitySeverity.LOW,
+    method=VulnerabilityScoreSource.CVSS_V3_1,
+    vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+)
+vuln1.ratings.add(rating1)
+bom.vulnerabilities.add(vuln1)
+affects1_range = [BomTargetVersionRange(range="vers:semver/<=1.8.0.update_382|<=11.0.20|<=17.0.8|<=20.0.2", status=ImpactAnalysisAffectedStatus.AFFECTED)]
+affects1 = BomTarget(ref="temurin-vdr")
+vuln1.affects.add(affects1)
+
+my_json_outputter: 'JsonOutputter' = JsonV1Dot4(bom)
+serialized_json = my_json_outputter.output_as_string(indent=2)
+print(serialized_json)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 beautifulsoup4
 requests
+cyclonedx-python-lib


### PR DESCRIPTION
manually create version of the bom here: https://github.com/tellison/testing/blob/master/temurin-vdr.json using the cyclone dx lib

output looks like:
```
{
  "dependencies": [
    {
      "ref": "temurin-vdr"
    }
  ],
  "metadata": {
    "component": {
      "bom-ref": "temurin-vdr",
      "licenses": [
        {
          "license": {
            "name": "GPL v2"
          }
        }
      ],
      "name": "Eclipse Temurin",
      "type": "application"
    },
    "timestamp": "2023-11-21T07:02:43.333268+00:00",
    "tools": [
      {
        "externalReferences": [
          {
            "type": "build-system",
            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/actions"
          },
          {
            "type": "distribution",
            "url": "https://pypi.org/project/cyclonedx-python-lib/"
          },
          {
            "type": "documentation",
            "url": "https://cyclonedx-python-library.readthedocs.io/"
          },
          {
            "type": "issue-tracker",
            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/issues"
          },
          {
            "type": "license",
            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/LICENSE"
          },
          {
            "type": "release-notes",
            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/blob/main/CHANGELOG.md"
          },
          {
            "type": "vcs",
            "url": "https://github.com/CycloneDX/cyclonedx-python-lib"
          },
          {
            "type": "website",
            "url": "https://github.com/CycloneDX/cyclonedx-python-lib/#readme"
          }
        ],
        "name": "cyclonedx-python-lib",
        "vendor": "CycloneDX",
        "version": "5.1.1"
      }
    ]
  },
  "serialNumber": "urn:uuid:30bb51e3-7443-450f-ab66-b53295003350",
  "version": 1,
  "vulnerabilities": [
    {
      "affects": [
        {
          "ref": "temurin-vdr"
        }
      ],
      "bom-ref": "d5c780f2-89a8-443d-b77f-fdd5b2c38f9f",
      "description": "hb-ot-layout-gsubgpos.hh in HarfBuzz through 6.0.0 allows attackers to trigger O(n^2) growth via consecutive marks during the process of looking back for base glyphs when attaching marks.",
      "id": "CVE-2-23-25193",
      "published": "2023-02-04T20:15:08.027000",
      "ratings": [
        {
          "method": "CVSSv31",
          "score": "3.7",
          "severity": "low",
          "source": {
            "name": "OJVG",
            "url": "https://openjdk.org/groups/vulnerability/advisories"
          },
          "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
        }
      ],
      "recommendation": "Upgrade to the latest version of Eclipse Temurin.",
      "source": {
        "name": "NVD",
        "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25193"
      },
      "updated": "2023-07-25T15:15:13.163000"
    }
  ],
  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
  "bomFormat": "CycloneDX",
  "specVersion": "1.4"
}
```